### PR TITLE
MPL simulator: implement more gates and remove non-standard / unused gates

### DIFF
--- a/feynsum-sml/src/common/Circuit.sml
+++ b/feynsum-sml/src/common/Circuit.sml
@@ -121,6 +121,8 @@ struct
 
           | ("t", 0, 1) => GateDefn.T (getArg 0)
 
+          | ("tdg", 0, 1) => GateDefn.Tdg (getArg 0)
+
           | ("x", 0, 1) => GateDefn.X (getArg 0)
 
           | ("sxdg", 0, 1) => GateDefn.Sxdg (getArg 0)
@@ -233,6 +235,7 @@ struct
         | GateDefn.PauliZ i => "z " ^ qi i
         | GateDefn.Hadamard i => "h " ^ qi i
         | GateDefn.T i => "t " ^ qi i
+        | GateDefn.Tdg i => "tdg " ^ qi i
         | GateDefn.SqrtX i => "sx " ^ qi i
         | GateDefn.Sxdg i => "sxdg " ^ qi i
         | GateDefn.S i => "s " ^ qi i

--- a/feynsum-sml/src/common/Gate.sml
+++ b/feynsum-sml/src/common/Gate.sml
@@ -413,6 +413,19 @@ struct
     end
 
 
+  fun tdg qi =
+    let
+      val mult = C.make (recp_sqrt_2, R.~ recp_sqrt_2)
+
+      fun apply (bidx, weight) =
+        let val weight' = if B.get bidx qi then C.* (weight, mult) else weight
+        in (bidx, weight')
+        end
+    in
+      makePushPull {touches = Seq.singleton qi, action = NonBranching apply}
+    end
+
+
   fun x qi =
     let
       fun apply (bidx, weight) =
@@ -815,6 +828,7 @@ struct
     | GateDefn.PauliZ xx => pauliz xx
     | GateDefn.Hadamard xx => hadamard xx
     | GateDefn.T xx => t xx
+    | GateDefn.Tdg xx => tdg xx
     | GateDefn.SqrtX xx => sqrtx xx
     | GateDefn.Sxdg xx => sxdg xx
     | GateDefn.S xx => s xx

--- a/feynsum-sml/src/common/GateDefn.sml
+++ b/feynsum-sml/src/common/GateDefn.sml
@@ -13,6 +13,7 @@ struct
   | Sdg of qubit_idx
   | X of qubit_idx
   | T of qubit_idx
+  | Tdg of qubit_idx
   | CX of {control: qubit_idx, target: qubit_idx}
   | CZ of {control: qubit_idx, target: qubit_idx}
   | CCX of {control1: qubit_idx, control2: qubit_idx, target: qubit_idx}


### PR DESCRIPTION
This patch adds the following gates: `s`, `sdg`, `sxdg`, `tdg`

and removes these (unused, nonstandard) gates: `sqrt(Y)`, `sqrt(W)`

See #3.