### PR TITLE
Store pullaction as partial computation

### DIFF
--- a/feynsum-rust/src/circuit.rs
+++ b/feynsum-rust/src/circuit.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use crate::parser::{Argument, Expression, OpCode, QasmStatement};
 use crate::types::{QubitIndex, Real};
-pub use gate::{Gate, GateDefn, PullApplicable, PullApplyOutput, PushApplicable, PushApplyOutput};
+pub use gate::{Gate, GateDefn, PullApplyOutput, PushApplicable, PushApplyOutput};
 
 #[derive(Debug)]
 pub enum CircuitBuildError {
@@ -17,7 +17,6 @@ pub enum CircuitBuildError {
     UnsupportedOpcode,
 }
 
-#[derive(Debug)]
 pub struct Circuit {
     pub num_qubits: usize,
     pub gates: Vec<Gate>,

--- a/feynsum-rust/src/circuit/gate.rs
+++ b/feynsum-rust/src/circuit/gate.rs
@@ -104,133 +104,238 @@ pub trait PushApplicable {
     fn push_apply(&self, bidx: BasisIdx, weight: Complex) -> PushApplyOutput;
 }
 
-pub trait PullApplicable {
-    fn pull_apply(&self, bidx: BasisIdx) -> PullApplyOutput;
-}
+type PullAction = Box<dyn Fn(BasisIdx) -> PullApplyOutput + Send + Sync>;
 
-#[derive(Debug)]
 pub struct Gate {
     defn: GateDefn,
     pub touches: Vec<QubitIndex>,
+    pub pull_action: Option<PullAction>,
 }
 
 impl Gate {
     pub fn new(defn: GateDefn) -> Self {
-        let touches = match &defn {
-            &GateDefn::Hadamard(qi)
-            | &GateDefn::PauliY(qi)
-            | &GateDefn::PauliZ(qi)
-            | &GateDefn::Phase { target: qi, .. }
-            | &GateDefn::S(qi)
-            | &GateDefn::Sdg(qi)
-            | &GateDefn::SqrtW(qi)
-            | &GateDefn::SqrtX(qi)
-            | &GateDefn::SqrtXdg(qi)
-            | &GateDefn::T(qi)
-            | &GateDefn::Tdg(qi)
-            | &GateDefn::X(qi) => vec![qi],
-            &GateDefn::CPhase {
-                control, target, ..
-            }
-            | &GateDefn::CZ { control, target }
-            | &GateDefn::CX { control, target } => vec![control, target],
-            &GateDefn::CCX {
-                control1,
-                control2,
-                target,
-            } => vec![control1, control2, target],
-            &GateDefn::FSim { left, right, .. } => vec![left, right],
-            &GateDefn::RX { target, .. }
-            | &GateDefn::RY { target, .. }
-            | &GateDefn::RZ { target, .. } => vec![target],
-            &GateDefn::CSwap {
-                control,
-                target1,
-                target2,
-            } => vec![control, target1, target2],
-            &GateDefn::Swap { target1, target2 } => vec![target1, target2],
-            &GateDefn::U { target, .. } => vec![target],
-            &GateDefn::Other { .. } => vec![],
-        };
-        Self { defn, touches }
-    }
-
-    fn branching_type(&self) -> BranchingType {
-        match self.defn {
-            GateDefn::CCX { .. }
-            | GateDefn::CPhase { .. }
-            | GateDefn::CSwap { .. }
-            | GateDefn::CX { .. }
-            | GateDefn::CZ { .. }
-            | GateDefn::PauliY(_)
-            | GateDefn::PauliZ(_)
-            | GateDefn::Phase { .. }
-            | GateDefn::RZ { .. }
-            | GateDefn::S(_)
-            | GateDefn::Sdg(_)
-            | GateDefn::Swap { .. }
-            | GateDefn::T(_)
-            | GateDefn::Tdg(_)
-            | GateDefn::X(_) => BranchingType::Nonbranching,
-            GateDefn::Hadamard(_)
-            | GateDefn::RY { .. }
-            | GateDefn::SqrtW(_)
-            | GateDefn::SqrtX(_)
-            | GateDefn::SqrtXdg(_) => BranchingType::Branching,
-            GateDefn::FSim { .. } | GateDefn::RX { .. } | GateDefn::U { .. } => {
-                BranchingType::MaybeBranching
-            }
-            GateDefn::Other { .. } => unimplemented!(),
+        let touches = create_touches(&defn);
+        let pull_action = create_pull_action(&defn, &touches);
+        Self {
+            defn,
+            touches,
+            pull_action,
         }
     }
 
     pub fn is_branching(&self) -> bool {
-        self.branching_type() != BranchingType::Nonbranching
+        self.defn.branching_type() != BranchingType::Nonbranching
         // NOTE: We assume MaybeBranching as Branching
     }
 
     // TODO: refactor to make this always consistent with pull_apply
     pub fn is_pullable(&self) -> bool {
-        match self.defn {
-            GateDefn::CX { .. }
-            | GateDefn::CZ { .. }
-            | GateDefn::Hadamard(_)
-            | GateDefn::RX { .. }
-            | GateDefn::RY { .. }
-            | GateDefn::RZ { .. }
-            | GateDefn::SqrtX(_)
-            | GateDefn::SqrtXdg(_)
-            | GateDefn::Swap { .. }
-            | GateDefn::U { .. } => true,
-            GateDefn::CCX { .. }
-            | GateDefn::CPhase { .. }
-            | GateDefn::CSwap { .. }
-            | GateDefn::FSim { .. }
-            | GateDefn::Phase { .. }
-            | GateDefn::PauliY(_)
-            | GateDefn::PauliZ(_)
-            | GateDefn::S(_)
-            | GateDefn::Sdg(_)
-            | GateDefn::SqrtW(_)
-            | GateDefn::T(_)
-            | GateDefn::Tdg(_)
-            | GateDefn::X(_) => {
-                matches!(
-                    (self.touches.len(), self.branching_type()),
-                    // We have not yet implemented pull action for other gates
-                    (1, BranchingType::Nonbranching)
-                        | (2, BranchingType::Nonbranching)
-                        | (1, BranchingType::Branching)
+        self.pull_action.is_some()
+    }
+}
+
+fn create_touches(defn: &GateDefn) -> Vec<QubitIndex> {
+    match *defn {
+        GateDefn::Hadamard(qi)
+        | GateDefn::PauliY(qi)
+        | GateDefn::PauliZ(qi)
+        | GateDefn::Phase { target: qi, .. }
+        | GateDefn::S(qi)
+        | GateDefn::Sdg(qi)
+        | GateDefn::SqrtW(qi)
+        | GateDefn::SqrtX(qi)
+        | GateDefn::SqrtXdg(qi)
+        | GateDefn::T(qi)
+        | GateDefn::Tdg(qi)
+        | GateDefn::X(qi) => vec![qi],
+        GateDefn::CPhase {
+            control, target, ..
+        }
+        | GateDefn::CZ { control, target }
+        | GateDefn::CX { control, target } => vec![control, target],
+        GateDefn::CCX {
+            control1,
+            control2,
+            target,
+        } => vec![control1, control2, target],
+        GateDefn::FSim { left, right, .. } => vec![left, right],
+        GateDefn::RX { target, .. } | GateDefn::RY { target, .. } | GateDefn::RZ { target, .. } => {
+            vec![target]
+        }
+        GateDefn::CSwap {
+            control,
+            target1,
+            target2,
+        } => vec![control, target1, target2],
+        GateDefn::Swap { target1, target2 } => vec![target1, target2],
+        GateDefn::U { target, .. } => vec![target],
+        GateDefn::Other { .. } => vec![],
+    }
+}
+
+fn create_pull_action(defn: &GateDefn, touches: &[QubitIndex]) -> Option<PullAction> {
+    match *defn {
+        GateDefn::CCX { .. }
+        | GateDefn::CPhase { .. }
+        | GateDefn::CSwap { .. }
+        | GateDefn::Swap { .. }
+        | GateDefn::FSim { .. }
+        | GateDefn::PauliY(_)
+        | GateDefn::PauliZ(_)
+        | GateDefn::S(_)
+        | GateDefn::Sdg(_)
+        | GateDefn::SqrtW(_)
+        | GateDefn::T(_)
+        | GateDefn::Tdg(_)
+        | GateDefn::X(_) => push_to_pull(defn, touches),
+        GateDefn::CX { control, target } => Some(Box::new(move |bidx| {
+            if bidx.get(control) {
+                PullApplyOutput::Nonbranching(bidx.flip(target), Complex::new(1.0, 0.0))
+            } else {
+                PullApplyOutput::Nonbranching(bidx, Complex::new(1.0, 0.0))
+            }
+        })),
+        GateDefn::CZ { control, target } => Some(Box::new(move |bidx| {
+            if bidx.get(control) && bidx.get(target) {
+                PullApplyOutput::Nonbranching(bidx, Complex::new(-1.0, 0.0))
+            } else {
+                PullApplyOutput::Nonbranching(bidx, Complex::new(1.0, 0.0))
+            }
+        })),
+        GateDefn::Hadamard(qi) => Some(Box::new(move |bidx| {
+            let bidx0 = bidx.unset(qi);
+            let bidx1 = bidx.set(qi);
+
+            if bidx.get(qi) {
+                PullApplyOutput::Branching(
+                    (bidx0, Complex::new(constants::RECP_SQRT_2, 0.0)),
+                    (bidx1, Complex::new(-constants::RECP_SQRT_2, 0.0)),
+                )
+            } else {
+                PullApplyOutput::Branching(
+                    (bidx0, Complex::new(constants::RECP_SQRT_2, 0.0)),
+                    (bidx1, Complex::new(constants::RECP_SQRT_2, 0.0)),
                 )
             }
-            GateDefn::Other { .. } => false,
+        })),
+        GateDefn::Phase { rot, target } => {
+            let cos = rot.cos();
+            let sin = rot.sin();
+
+            Some(Box::new(move |bidx| {
+                if bidx.get(target) {
+                    PullApplyOutput::Nonbranching(bidx, Complex::new(cos, sin))
+                } else {
+                    PullApplyOutput::Nonbranching(bidx, Complex::new(1.0, 0.0))
+                }
+            }))
+        }
+        GateDefn::RX { rot, target } => {
+            let cos = Complex::new((rot / 2.0).cos(), 0.0);
+            let sin = Complex::new((rot / 2.0).sin(), 0.0);
+            let a = cos;
+            let b = sin * Complex::new(0.0, -1.0);
+            let c = b;
+            let d = a;
+            Some(Box::new(move |bidx| {
+                single_qubit_unitary_pull(bidx, target, a, b, c, d)
+            }))
+        }
+        GateDefn::RY { rot, target } => {
+            let cos = (rot / 2.0).cos();
+            let sin = (rot / 2.0).sin();
+
+            Some(Box::new(move |bidx| {
+                let bidx0 = bidx.unset(target);
+                let bidx1 = bidx.set(target);
+
+                if bidx.get(target) {
+                    PullApplyOutput::Branching(
+                        (bidx0, Complex::new(sin, 0.0)),
+                        (bidx1, Complex::new(cos, 0.0)),
+                    )
+                } else {
+                    PullApplyOutput::Branching(
+                        (bidx0, Complex::new(cos, 0.0)),
+                        (bidx1, Complex::new(-sin, 0.0)),
+                    )
+                }
+            }))
+        }
+        GateDefn::RZ { rot, target } => {
+            let cos = (rot / 2.0).cos();
+            let sin = (rot / 2.0).sin();
+
+            Some(Box::new(move |bidx| {
+                if bidx.get(target) {
+                    PullApplyOutput::Nonbranching(bidx, Complex::new(cos, sin))
+                } else {
+                    PullApplyOutput::Nonbranching(bidx, Complex::new(cos, -sin))
+                }
+            }))
+        }
+        GateDefn::SqrtX(qi) => Some(Box::new(move |bidx| {
+            let bidx0 = bidx.unset(qi);
+            let bidx1 = bidx.set(qi);
+
+            if bidx.get(qi) {
+                PullApplyOutput::Branching(
+                    (bidx0, Complex::new(0.5, -0.5)),
+                    (bidx1, Complex::new(0.5, 0.5)),
+                )
+            } else {
+                PullApplyOutput::Branching(
+                    (bidx0, Complex::new(0.5, 0.5)),
+                    (bidx1, Complex::new(0.5, -0.5)),
+                )
+            }
+        })),
+        GateDefn::SqrtXdg(qi) => Some(Box::new(move |bidx| {
+            let bidx0 = bidx.unset(qi);
+            let bidx1 = bidx.set(qi);
+
+            if bidx.get(qi) {
+                PullApplyOutput::Branching(
+                    (bidx0, Complex::new(0.5, 0.5)),
+                    (bidx1, Complex::new(0.5, -0.5)),
+                )
+            } else {
+                PullApplyOutput::Branching(
+                    (bidx0, Complex::new(0.5, -0.5)),
+                    (bidx1, Complex::new(0.5, 0.5)),
+                )
+            }
+        })),
+        GateDefn::U {
+            target,
+            theta,
+            phi,
+            lambda,
+        } => {
+            let cos = Complex::new((theta / 2.0).cos(), 0.0);
+            let sin = Complex::new((theta / 2.0).sin(), 0.0);
+
+            let a = cos;
+            let b = -sin * Complex::new(lambda.cos(), lambda.sin());
+            let c = sin * Complex::new(phi.cos(), phi.sin());
+            let d = cos * Complex::new((phi + lambda).cos(), (phi + lambda).sin());
+
+            assert!(!(utility::is_zero(a) && utility::is_zero(b)));
+            assert!(!(utility::is_zero(c) && utility::is_zero(d)));
+
+            Some(Box::new(move |bidx| {
+                single_qubit_unitary_pull(bidx, target, a, b, c, d)
+            }))
+        }
+        GateDefn::Other { .. } => {
+            unimplemented!()
         }
     }
 }
 
-impl PushApplicable for Gate {
+impl GateDefn {
     fn push_apply(&self, bidx: BasisIdx, weight: Complex) -> PushApplyOutput {
-        match self.defn {
+        match *self {
             GateDefn::CCX {
                 control1,
                 control2,
@@ -477,6 +582,35 @@ impl PushApplicable for Gate {
             GateDefn::Other { .. } => unimplemented!(),
         }
     }
+
+    fn branching_type(&self) -> BranchingType {
+        match self {
+            GateDefn::CCX { .. }
+            | GateDefn::CPhase { .. }
+            | GateDefn::CSwap { .. }
+            | GateDefn::CX { .. }
+            | GateDefn::CZ { .. }
+            | GateDefn::PauliY(_)
+            | GateDefn::PauliZ(_)
+            | GateDefn::Phase { .. }
+            | GateDefn::RZ { .. }
+            | GateDefn::S(_)
+            | GateDefn::Sdg(_)
+            | GateDefn::Swap { .. }
+            | GateDefn::T(_)
+            | GateDefn::Tdg(_)
+            | GateDefn::X(_) => BranchingType::Nonbranching,
+            GateDefn::Hadamard(_)
+            | GateDefn::RY { .. }
+            | GateDefn::SqrtW(_)
+            | GateDefn::SqrtX(_)
+            | GateDefn::SqrtXdg(_) => BranchingType::Branching,
+            GateDefn::FSim { .. } | GateDefn::RX { .. } | GateDefn::U { .. } => {
+                BranchingType::MaybeBranching
+            }
+            GateDefn::Other { .. } => unimplemented!(),
+        }
+    }
 }
 
 fn single_qubit_unitary_push(
@@ -544,307 +678,164 @@ fn single_qubit_unitary_pull(
     }
 }
 
-// NOTE: We may store partial computation of this
-// to further optimize performance
-macro_rules! push_to_pull {
-    ($self:ident, $bidx:ident) => {{
-        let touches = &$self.touches;
-        debug!(
-            "pulling touches: {}, {:?} gate: {:?}",
-            touches.len(),
-            $self.branching_type(),
-            $self
-        );
-        match (touches.len(), $self.branching_type()) {
-            (1, BranchingType::Nonbranching) => {
-                let qi = touches[0];
+fn push_to_pull(defn: &GateDefn, touches: &[QubitIndex]) -> Option<PullAction> {
+    match (touches.len(), defn.branching_type()) {
+        (1, BranchingType::Nonbranching) => {
+            let qi = touches[0];
 
-                let (b0, m0) = match $self.push_apply(BasisIdx::zeros(), Complex::new(1.0, 0.0)) {
-                    PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
-                    _ => unreachable!("push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Nonbranching"),
-                };
+            let (b0, m0) = match defn.push_apply(BasisIdx::zeros(), Complex::new(1.0, 0.0)) {
+                PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
+                _ => unreachable!(
+                    "push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Nonbranching"
+                ),
+            };
 
-                let (_bidx2, m1) =
-                    match $self.push_apply(BasisIdx::zeros().set(qi), Complex::new(1.0, 0.0)) {
+            let (_bidx2, m1) =
+                    match defn.push_apply(BasisIdx::zeros().set(qi), Complex::new(1.0, 0.0)) {
                         PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
                     _ => unreachable!("push_apply(BasisIdx::zeros().set(qi), Complex::new(1.0,0.0)) must return Nonbranching"),
                     };
 
-                if b0 == BasisIdx::zeros() {
-                    PullApplyOutput::Nonbranching($bidx, if $bidx.get(qi) { m1 } else { m0 })
-                } else {
-                    PullApplyOutput::Nonbranching(
-                        $bidx.flip(qi),
-                        if $bidx.get(qi) { m0 } else { m1 },
-                    )
-                }
+            if b0 == BasisIdx::zeros() {
+                Some(Box::new(move |bidx| {
+                    PullApplyOutput::Nonbranching(bidx, if bidx.get(qi) { m1 } else { m0 })
+                }))
+            } else {
+                Some(Box::new(move |bidx| {
+                    PullApplyOutput::Nonbranching(bidx.flip(qi), if bidx.get(qi) { m0 } else { m1 })
+                }))
             }
-            (2, BranchingType::Nonbranching) => {
-                let qi = touches[0];
-                let qj = touches[1];
+        }
+        (2, BranchingType::Nonbranching) => {
+            let qi = touches[0];
+            let qj = touches[1];
 
-                let a00 = BasisIdx::zeros();
-                let a01 = BasisIdx::zeros().set(qj);
-                let a10 = BasisIdx::zeros().set(qi);
-                let a11 = BasisIdx::zeros().set(qi).set(qj);
+            let a00 = BasisIdx::zeros();
+            let a01 = BasisIdx::zeros().set(qj);
+            let a10 = BasisIdx::zeros().set(qi);
+            let a11 = BasisIdx::zeros().set(qi).set(qj);
 
-                let (b00, m00) = match $self.push_apply(a00, Complex::new(1.0, 0.0)) {
-                    PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
-                    _ => unreachable!("push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Nonbranching"),
-                };
+            let (b00, m00) = match defn.push_apply(a00, Complex::new(1.0, 0.0)) {
+                PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
+                _ => unreachable!(
+                    "push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Nonbranching"
+                ),
+            };
 
-                let (b01, m01) =
-                    match $self.push_apply(a01, Complex::new(1.0, 0.0)) {
+            let (b01, m01) =
+                    match defn.push_apply(a01, Complex::new(1.0, 0.0)) {
                         PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
                         _ => unreachable!("push_apply(BasisIdx::zeros().set(qj), Complex::new(1.0,0.0)) must return Nonbranching"),
                     };
 
-                let (b10, m10) =
-                    match $self.push_apply(a10, Complex::new(1.0, 0.0)) {
+            let (b10, m10) =
+                    match defn.push_apply(a10, Complex::new(1.0, 0.0)) {
                         PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
                         _ => unreachable!("push_apply(BasisIdx::zeros().set(qi), Complex::new(1.0,0.0)) must return Nonbranching"),
                     };
 
-                let (b11, m11) = match $self
+            let (b11, m11) = match defn
                     .push_apply(a11, Complex::new(1.0, 0.0))
                 {
                     PushApplyOutput::Nonbranching(bidx, multiplier) => (bidx, multiplier),
                     _ => unreachable!("push_apply(BasisIdx::zeros().set(qi).set(qj), Complex::new(1.0,0.0)) must return Nonbranching"),
                 };
 
-                let apply_match = |left: bool, right: bool, bb: &BasisIdx| -> bool {
-                        left == bb.get(qi) && right == bb.get(qj)
-                    };
-                    let find = |left: bool, right: bool| -> (BasisIdx, Complex) {
-                        if apply_match(left, right, &b00) {
-                            (a00, m00.clone())
-                        } else if apply_match(left, right, &b01) {
-                            (a01, m01.clone())
-                        } else if apply_match(left, right, &b10) {
-                            (a10, m10.clone())
-                        } else if apply_match(left, right, &b11) {
-                            (a11, m11.clone())
-                        } else {
-                            unreachable!("apply_match must return true for one of the basis")
-                        }
-                    };
-
-
-                let align_with = |bb: &BasisIdx, bidx: &BasisIdx| -> BasisIdx {
-                    match (bb.get(qi), bb.get(qj)) {
-                        (true, true) => bidx.set(qi).set(qj),
-                        (true, false) => bidx.set(qi).unset(qj),
-                        (false, true) => bidx.unset(qi).set(qj),
-                        (false, false) => bidx.unset(qi).unset(qj),
-                    }
-                };
-
-                match ($bidx.get(qi), $bidx.get(qj)) {
-                    (true, true) => {
-                        PullApplyOutput::Nonbranching(align_with(&b11, &$bidx), m11)
-                    }
-                    (true, false) => {
-                        PullApplyOutput::Nonbranching(align_with(&b10, &$bidx), m10)
-                    }
-                    (false, true) => {
-                        PullApplyOutput::Nonbranching(align_with(&b01, &$bidx), m01)
-                    }
-                    (false, false) => {
-                        PullApplyOutput::Nonbranching(align_with(&b00, &$bidx), m00)
-                    }
+            let apply_match = |left: bool, right: bool, bb: &BasisIdx| -> bool {
+                left == bb.get(qi) && right == bb.get(qj)
+            };
+            let find = |left: bool, right: bool| -> (BasisIdx, Complex) {
+                if apply_match(left, right, &b00) {
+                    (a00, m00.clone())
+                } else if apply_match(left, right, &b01) {
+                    (a01, m01.clone())
+                } else if apply_match(left, right, &b10) {
+                    (a10, m10.clone())
+                } else if apply_match(left, right, &b11) {
+                    (a11, m11.clone())
+                } else {
+                    unreachable!("apply_match must return true for one of the basis")
                 }
-            }
-            (1, BranchingType::Branching) => {
-                let qi = touches[0];
+            };
 
-                let PushApplyOutput::Branching((b00, m00), (b01, m01)) =
-                    $self.push_apply(BasisIdx::zeros(), Complex::new(1.0, 0.0))
-                else {
-                    unreachable!("push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Branching")
-                };
+            let (new_b00, new_m00) = find(false, false);
+            let (new_b01, new_m01) = find(false, true);
+            let (new_b10, new_m10) = find(true, false);
+            let (new_b11, new_m11) = find(true, true);
 
-                let PushApplyOutput::Branching((b10, m10), (b11, m11)) =
-                    $self.push_apply(BasisIdx::zeros().set(qi), Complex::new(1.0, 0.0))
-                else {
-                    unreachable!("push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Branching")
-                };
-
-                let ((b00, m00), (b01, m01)) = if b00.get(qi) {
-                    ((b01, m01), (b00, m00))
-                } else {
-                    ((b00, m00), (b01, m01))
-                };
-
-                let ((b10, m10), (b11, m11)) = if b10.get(qi) {
-                    ((b11, m11), (b10, m10))
-                } else {
-                    ((b10, m10), (b11, m11))
-                };
-
-                assert!(!b00.get(qi) && !b10.get(qi) && b01.get(qi) && b11.get(qi));
-
-                if $bidx.get(qi) {
-                    PullApplyOutput::Branching(($bidx.unset(qi), m01), ($bidx, m11))
-                } else {
-                    let bidx2 = $bidx.set(qi);
-                    PullApplyOutput::Branching(($bidx, m00), (bidx2, m10))
+            let align_with = move |bb: &BasisIdx, bidx: &BasisIdx| -> BasisIdx {
+                match (bb.get(qi), bb.get(qj)) {
+                    (true, true) => bidx.set(qi).set(qj),
+                    (true, false) => bidx.set(qi).unset(qj),
+                    (false, true) => bidx.unset(qi).set(qj),
+                    (false, false) => bidx.unset(qi).unset(qj),
                 }
-            }
+            };
 
-            _ => unimplemented!("pull action for {:?} not supported at this moment", $self),
+            Some(Box::new(move |bidx| match (bidx.get(qi), bidx.get(qj)) {
+                (true, true) => PullApplyOutput::Nonbranching(align_with(&new_b11, &bidx), new_m11),
+                (true, false) => {
+                    PullApplyOutput::Nonbranching(align_with(&new_b10, &bidx), new_m10)
+                }
+                (false, true) => {
+                    PullApplyOutput::Nonbranching(align_with(&new_b01, &bidx), new_m01)
+                }
+                (false, false) => {
+                    PullApplyOutput::Nonbranching(align_with(&new_b00, &bidx), new_m00)
+                }
+            }))
         }
-    }};
+        (1, BranchingType::Branching) => {
+            let qi = touches[0];
+
+            let PushApplyOutput::Branching((b00, m00), (b01, m01)) =
+                defn.push_apply(BasisIdx::zeros(), Complex::new(1.0, 0.0))
+            else {
+                unreachable!(
+                    "push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Branching"
+                )
+            };
+
+            let PushApplyOutput::Branching((b10, m10), (b11, m11)) =
+                defn.push_apply(BasisIdx::zeros().set(qi), Complex::new(1.0, 0.0))
+            else {
+                unreachable!(
+                    "push_apply(BasisIdx::zeros(), Complex::new(1.0,0.0)) must return Branching"
+                )
+            };
+
+            let ((b00, m00), (b01, m01)) = if b00.get(qi) {
+                ((b01, m01), (b00, m00))
+            } else {
+                ((b00, m00), (b01, m01))
+            };
+
+            let ((b10, m10), (b11, m11)) = if b10.get(qi) {
+                ((b11, m11), (b10, m10))
+            } else {
+                ((b10, m10), (b11, m11))
+            };
+
+            assert!(!b00.get(qi) && !b10.get(qi) && b01.get(qi) && b11.get(qi));
+
+            Some(Box::new(move |bidx| {
+                if bidx.get(qi) {
+                    PullApplyOutput::Branching((bidx.unset(qi), m01), (bidx, m11))
+                } else {
+                    let bidx2 = bidx.set(qi);
+                    PullApplyOutput::Branching((bidx, m00), (bidx2, m10))
+                }
+            }))
+        }
+        _ => {
+            debug!("pull action for {:?} not supported at this moment", defn);
+            None
+        }
+    }
 }
 
-impl PullApplicable for Gate {
-    fn pull_apply(&self, bidx: BasisIdx) -> PullApplyOutput {
-        match self.defn {
-            GateDefn::CCX { .. }
-            | GateDefn::CPhase { .. }
-            | GateDefn::CSwap { .. }
-            | GateDefn::Swap { .. }
-            | GateDefn::FSim { .. }
-            | GateDefn::PauliY(_)
-            | GateDefn::PauliZ(_)
-            | GateDefn::S(_)
-            | GateDefn::Sdg(_)
-            | GateDefn::SqrtW(_)
-            | GateDefn::T(_)
-            | GateDefn::Tdg(_)
-            | GateDefn::X(_) => {
-                assert!(self.is_pullable());
-                push_to_pull!(self, bidx)
-            }
-
-            GateDefn::CX { control, target } => {
-                if bidx.get(control) {
-                    PullApplyOutput::Nonbranching(bidx.flip(target), Complex::new(1.0, 0.0))
-                } else {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(1.0, 0.0))
-                }
-            }
-            GateDefn::CZ { control, target } => {
-                if bidx.get(control) && bidx.get(target) {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(-1.0, 0.0))
-                } else {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(1.0, 0.0))
-                }
-            }
-            GateDefn::Hadamard(qi) => {
-                let bidx0 = bidx.unset(qi);
-                let bidx1 = bidx.set(qi);
-
-                if bidx.get(qi) {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(constants::RECP_SQRT_2, 0.0)),
-                        (bidx1, Complex::new(-constants::RECP_SQRT_2, 0.0)),
-                    )
-                } else {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(constants::RECP_SQRT_2, 0.0)),
-                        (bidx1, Complex::new(constants::RECP_SQRT_2, 0.0)),
-                    )
-                }
-            }
-            GateDefn::Phase { rot, target } => {
-                if bidx.get(target) {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(rot.cos(), rot.sin()))
-                } else {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(1.0, 0.0))
-                }
-            }
-            GateDefn::RX { rot, target } => {
-                let cos = Complex::new((rot / 2.0).cos(), 0.0);
-                let sin = Complex::new((rot / 2.0).sin(), 0.0);
-                let a = cos;
-                let b = sin * Complex::new(0.0, -1.0);
-                let c = b;
-                let d = a;
-
-                single_qubit_unitary_pull(bidx, target, a, b, c, d)
-            }
-            GateDefn::RY { rot, target } => {
-                let bidx0 = bidx.unset(target);
-                let bidx1 = bidx.set(target);
-
-                let cos = (rot / 2.0).cos();
-                let sin = (rot / 2.0).sin();
-
-                if bidx.get(target) {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(sin, 0.0)),
-                        (bidx1, Complex::new(cos, 0.0)),
-                    )
-                } else {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(cos, 0.0)),
-                        (bidx1, Complex::new(-sin, 0.0)),
-                    )
-                }
-            }
-            GateDefn::RZ { rot, target } => {
-                let cos = (rot / 2.0).cos();
-                let sin = (rot / 2.0).sin();
-                if bidx.get(target) {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(cos, sin))
-                } else {
-                    PullApplyOutput::Nonbranching(bidx, Complex::new(cos, -sin))
-                }
-            }
-            GateDefn::SqrtX(qi) => {
-                let bidx0 = bidx.unset(qi);
-                let bidx1 = bidx.set(qi);
-
-                if bidx.get(qi) {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(0.5, -0.5)),
-                        (bidx1, Complex::new(0.5, 0.5)),
-                    )
-                } else {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(0.5, 0.5)),
-                        (bidx1, Complex::new(0.5, -0.5)),
-                    )
-                }
-            }
-            GateDefn::SqrtXdg(qi) => {
-                let bidx0 = bidx.unset(qi);
-                let bidx1 = bidx.set(qi);
-
-                if bidx.get(qi) {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(0.5, 0.5)),
-                        (bidx1, Complex::new(0.5, -0.5)),
-                    )
-                } else {
-                    PullApplyOutput::Branching(
-                        (bidx0, Complex::new(0.5, -0.5)),
-                        (bidx1, Complex::new(0.5, 0.5)),
-                    )
-                }
-            }
-            GateDefn::U {
-                target,
-                theta,
-                phi,
-                lambda,
-            } => {
-                let cos = Complex::new((theta / 2.0).cos(), 0.0);
-                let sin = Complex::new((theta / 2.0).sin(), 0.0);
-
-                let a = cos;
-                let b = -sin * Complex::new(lambda.cos(), lambda.sin());
-                let c = sin * Complex::new(phi.cos(), phi.sin());
-                let d = cos * Complex::new((phi + lambda).cos(), (phi + lambda).sin());
-
-                assert!(!(utility::is_zero(a) && utility::is_zero(b)));
-                assert!(!(utility::is_zero(c) && utility::is_zero(d)));
-
-                single_qubit_unitary_pull(bidx, target, a, b, c, d)
-            }
-            GateDefn::Other { .. } => {
-                unimplemented!()
-            }
-        }
+impl PushApplicable for Gate {
+    fn push_apply(&self, bidx: BasisIdx, weight: Complex) -> PushApplyOutput {
+        self.defn.push_apply(bidx, weight)
     }
 }

--- a/feynsum-rust/src/simulator/parallel/bfs_simulator.rs
+++ b/feynsum-rust/src/simulator/parallel/bfs_simulator.rs
@@ -57,7 +57,7 @@ pub fn run(config: &Config, circuit: Circuit) -> Result<State, SimulatorError> {
             .map(|idx| &circuit.gates[idx])
             .collect::<Vec<_>>();
 
-        debug!("applying gates: {:?}", these_gates);
+        // debug!("applying gates: {:?}", these_gates);
 
         if these_gates.is_empty() {
             break;

--- a/feynsum-rust/src/simulator/sequential/bfs_simulator.rs
+++ b/feynsum-rust/src/simulator/sequential/bfs_simulator.rs
@@ -57,7 +57,7 @@ pub fn run(config: &Config, circuit: Circuit) -> Result<State, SimulatorError> {
             .map(|idx| &circuit.gates[idx])
             .collect::<Vec<_>>();
 
-        debug!("applying gates: {:?}", these_gates);
+        // FIXME: debug!("applying gates: {:?}", these_gates);
 
         if these_gates.is_empty() {
             break;

--- a/feynsum-rust/src/simulator/sequential/state_expander.rs
+++ b/feynsum-rust/src/simulator/sequential/state_expander.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 use std::fmt::{self, Display, Formatter};
 
-use crate::circuit::{Gate, PullApplicable, PullApplyOutput, PushApplicable, PushApplyOutput};
+use crate::circuit::{Gate, PullApplyOutput, PushApplicable, PushApplyOutput};
 use crate::config::Config;
 use crate::types::{BasisIdx, Complex, Real};
 use crate::utility;
@@ -168,7 +168,7 @@ fn apply_pull_gates(
         return Ok((weight, 0));
     }
 
-    match gates[0].pull_apply(*bidx) {
+    match gates[0].pull_action.as_ref().unwrap()(*bidx) {
         // FIXME: No clone
         PullApplyOutput::Nonbranching(neighbor, multiplier) => {
             let (weight, num_gate_apps) = apply_pull_gates(&gates[1..], prev_state, &neighbor)?;


### PR DESCRIPTION
This reduced the pull dense time in a large google circuit from 15.3s to 13s.
Also, it's better not to use macros if possible, because it makes code harder to debug.